### PR TITLE
Fix tag name replacement

### DIFF
--- a/run-containerized
+++ b/run-containerized
@@ -46,7 +46,7 @@ fi
 cd $DOCKER_CONTEXT_DIR
 
 # Deduce a tag name for the container we're going to build based on the Jenkins job name
-DOCKER_TAG_NAME=$(echo $JOB_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9\-\_.]//')
+DOCKER_TAG_NAME=$(echo $JOB_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9\-\_.]//g')
 
 # copy stdout to a new fd so we can display and capture it
 exec 5>&1

--- a/run-containerized
+++ b/run-containerized
@@ -46,7 +46,7 @@ fi
 cd $DOCKER_CONTEXT_DIR
 
 # Deduce a tag name for the container we're going to build based on the Jenkins job name
-DOCKER_TAG_NAME=$(echo $JOB_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9\-\_.]//g')
+DOCKER_TAG_NAME=$(echo $JOB_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^-a-z0-9_.]//g')
 
 # copy stdout to a new fd so we can display and capture it
 exec 5>&1


### PR DESCRIPTION
`run-containerized` replaces invalid characters in job name.
Since there is a bug in the regex, the script behaves like the following:

| Input (`$JOB_NAME`) | Output (`$DOCKER_TAG_NAME`) | Expected |
| --- | --- | --- |
| `folder1/folder2/job1` | `folder1folder2/job1` | `folder1folder2job1` |
| `job-name-1` | `jobname-1` | `job-name-1` |
