### PR TITLE
Allow usage of alternative Dockerfile names

### DIFF
--- a/run-containerized
+++ b/run-containerized
@@ -48,11 +48,14 @@ cd $DOCKER_CONTEXT_DIR
 # Deduce a tag name for the container we're going to build based on the Jenkins job name
 DOCKER_TAG_NAME=$(echo $JOB_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^-a-z0-9_.]//g')
 
+# Determine the Dockerfile to use for the build
+DOCKERFILE=${DOCKERFILE:-Dockerfile}
+
 # copy stdout to a new fd so we can display and capture it
 exec 5>&1
 
-echo "Building $DOCKER_TAG_NAME Docker image, this can take some..."
-BUILD=$(docker build -t $DOCKER_TAG_NAME . | tee >(cat - >&5))
+echo "Building $DOCKER_TAG_NAME Docker image from $DOCKERFILE, this can take some..."
+BUILD=$(docker build -f $DOCKERFILE -t $DOCKER_TAG_NAME . | tee >(cat - >&5))
 [ $? -eq 0 ] || abort "Docker image failed to build, check your Dockerfile."
 
 # Determine the image ID we've just built


### PR DESCRIPTION
By default, `docker build` uses `Dockerfile` in the root of the build context directory for the build, but this can be overridden using the `-f FILENAME` option.

This change allows an environment variable `$DOCKERFILE` to be optionally set to take advantage of this option. If unset, then the normal behaviour occurs, so this should be backwards compatible.
