### PR TITLE
Allow passing of options to docker build

### DIFF
--- a/run-containerized
+++ b/run-containerized
@@ -55,7 +55,7 @@ DOCKER_TAG_NAME=$(echo $JOB_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^-a-z0-9
 exec 5>&1
 
 echo "Building $DOCKER_TAG_NAME Docker image, this can take some..."
-BUILD=$(docker build -t $DOCKER_TAG_NAME . | tee >(cat - >&5))
+BUILD=$(docker build $DOCKER_BUILD_OPTS -t $DOCKER_TAG_NAME . | tee >(cat - >&5))
 [ $? -eq 0 ] || abort "Docker image failed to build, check your Dockerfile."
 
 # Determine the image ID we've just built


### PR DESCRIPTION
As discussed in #4, allowing the passing of options to `docker build` by way of `DOCKER_BUILD_OPTS`.
