### PR TITLE
Abort if not passed exactly one argument

### DIFF
--- a/run-containerized
+++ b/run-containerized
@@ -25,6 +25,10 @@ function abort() {
   exit 1
 }
 
+if [ $# -ne 1 ]; then
+  abort "$0 requires exactly one argument (of bash script)."
+fi
+
 # DOCKER_OPTS is now deprecated in favor of DOCKER_RUN_OPTS.
 # If it is set assign it to DOCKER_RUN_OPTS and print a warning.
 if [ -n "$DOCKER_OPTS" ]; then

--- a/run-containerized
+++ b/run-containerized
@@ -94,7 +94,7 @@ CID=$(docker run -it -d -v "$WORKSPACE:/workspace" \
                         $DOCKER_RUN_OPTS $DOCKER_IMG \
                         bash -c "INIT=/usr/local/bin/init-container ;\
                         [ -e \$INIT ] && \$INIT ;\
-                        $@ ;\
+                        $* ;\
                         JOB_RESULT=\$? ; chown -R $(id -u `whoami`) /workspace ;\
                         (exit \$JOB_RESULT)")
 set +x


### PR DESCRIPTION
To clarify usage expectations and preserve backward compatibility.

refs #10
