### PR TITLE
Support to use docker-compose

### DIFF
--- a/example-dockerfiles/docker-compose/docker-compose.yml
+++ b/example-dockerfiles/docker-compose/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3"
+services:
+
+  application-to-test:
+    image: ${DOCKER_IMG}
+    command: ${ENTRY_COMMAND}    
+    volumes:
+      - "${WORKSPACE}:/workspace"    

--- a/run-composed
+++ b/run-composed
@@ -16,6 +16,8 @@ function cleanupContainer() {
     if [ "$CONTAINER_RUNNING" = "true" ]; then
       echo "Cleaning up docker container"
 
+      docker-compose down
+
       # In regular workflows this is done automatically, but when the job is aborted
       # and the container is killed this cleanup won't happen, so do it here.
       docker exec $CID chown -R $(id -u `whoami`) /workspace
@@ -31,13 +33,6 @@ function abort() {
 
 if [ $# -ne 1 ]; then
   abort "$0 requires exactly one argument (of bash script)."
-fi
-
-# DOCKER_OPTS is now deprecated in favor of DOCKER_RUN_OPTS.
-# If it is set assign it to DOCKER_RUN_OPTS and print a warning.
-if [ -n "$DOCKER_OPTS" ]; then
-  >&2 echo '$DOCKER_OPTS is deprecated, please use $DOCKER_RUN_OPTS'
-  DOCKER_RUN_OPTS=$DOCKER_OPTS
 fi
 
 # Forward the SSH agent to the Docker container, useful in combination with

--- a/run-composed
+++ b/run-composed
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# See https://github.com/kabisaict/jenkins-docker for more information.
+# See https://github.com/kabisa/jenkins-docker for more information.
 #
 # Usage:
 # run-composed [CI command]
@@ -40,13 +40,6 @@ fi
 if [[ -n $SSH_AUTH_SOCK ]]; then
   DOCKER_OPTS="$DOCKER_OPTS -v $SSH_AUTH_SOCK:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock"
 fi
-
-# Where to store cachable artifacts. Docker containers ran by this script get
-# a /cache directory that's unique to the job and can be used to store any build
-# artifacts that should persist across builds. Think about Ruby gems, the local
-# Java Maven repository etc.
-CACHE_DIR=${CACHE_DIR:-/ci/cache}
-BUILD_CACHE_DIR="$CACHE_DIR/$JOB_NAME"
 
 # Projects that want to use this setup should maintain a Dockerfile in dockerfiles/ci
 # that describes the required build environment.

--- a/run-composed
+++ b/run-composed
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# See https://github.com/kabisaict/jenkins-docker for more information.
+#
+# Usage:
+# run-composed [CI command]
+#
+# Examples:
+# run-composed 'bin/ci'
+# run-composed 'mvn clean install'
+set -o pipefail
+trap cleanupContainer EXIT
+
+function cleanupContainer() {
+  if [ -n "$CID" ]; then
+    CONTAINER_RUNNING=$(docker inspect --format='{{.State.Running}}' $CID)
+    if [ "$CONTAINER_RUNNING" = "true" ]; then
+      echo "Cleaning up docker container"
+
+      # In regular workflows this is done automatically, but when the job is aborted
+      # and the container is killed this cleanup won't happen, so do it here.
+      docker exec $CID chown -R $(id -u `whoami`) /workspace
+      docker kill $CID > /dev/null
+    fi
+  fi
+}
+
+function abort() {
+  echo "$(tput setaf 1)$1$(tput sgr 0)"
+  exit 1
+}
+
+if [ $# -ne 1 ]; then
+  abort "$0 requires exactly one argument (of bash script)."
+fi
+
+# DOCKER_OPTS is now deprecated in favor of DOCKER_RUN_OPTS.
+# If it is set assign it to DOCKER_RUN_OPTS and print a warning.
+if [ -n "$DOCKER_OPTS" ]; then
+  >&2 echo '$DOCKER_OPTS is deprecated, please use $DOCKER_RUN_OPTS'
+  DOCKER_RUN_OPTS=$DOCKER_OPTS
+fi
+
+# Forward the SSH agent to the Docker container, useful in combination with
+# https://wiki.jenkins-ci.org/display/JENKINS/SSH+Agent+Plugin
+if [[ -n $SSH_AUTH_SOCK ]]; then
+  DOCKER_OPTS="$DOCKER_OPTS -v $SSH_AUTH_SOCK:/tmp/auth.sock -e SSH_AUTH_SOCK=/tmp/auth.sock"
+fi
+
+# Where to store cachable artifacts. Docker containers ran by this script get
+# a /cache directory that's unique to the job and can be used to store any build
+# artifacts that should persist across builds. Think about Ruby gems, the local
+# Java Maven repository etc.
+CACHE_DIR=${CACHE_DIR:-/ci/cache}
+BUILD_CACHE_DIR="$CACHE_DIR/$JOB_NAME"
+
+# Projects that want to use this setup should maintain a Dockerfile in dockerfiles/ci
+# that describes the required build environment.
+DOCKER_CONTEXT_DIR=${DOCKER_CONTEXT_DIR:-$WORKSPACE/dockerfiles/ci}
+
+if [ ! -d "$DOCKER_CONTEXT_DIR" ]; then
+  abort "No Dockerfile found in $DOCKER_CONTEXT_DIR"
+fi
+cd "$DOCKER_CONTEXT_DIR"
+
+# Deduce a tag name for the container we're going to build based on the Jenkins job name
+DOCKER_TAG_NAME=$(echo $JOB_NAME | tr '[:upper:]' '[:lower:]' | sed 's/[^-a-z0-9_.]//g')
+
+# copy stdout to a new fd so we can display and capture it
+exec 5>&1
+
+echo "Building $DOCKER_TAG_NAME Docker image, this can take some..."
+BUILD=$(docker build -q $DOCKER_BUILD_OPTS -t $DOCKER_TAG_NAME . | tee >(cat - >&5))
+[ $? -eq 0 ] || abort "Docker image failed to build, check your Dockerfile."
+
+# Determine the image ID we've just built
+DOCKER_IMG=$(echo "$BUILD" | tail -n 1 | rev | cut -d ' ' -f1 | rev)
+
+# Docker compose file should be kept in dockerfiles/ci directory
+cd $WORKSPACE/dockerfiles/ci;
+
+# Exporting these variables is required when referencing them in the docker-compose.yml
+# file
+
+# The main docker image which runs the CI job
+export DOCKER_IMG
+# Jenkins workspace
+export WORKSPACE
+# entry command to start the application (typically bin/ci )
+export ENTRY_COMMAND="$1"
+
+set -x
+
+# Now actually run the Docker container.
+docker-compose up -d
+CID=$(docker ps -q -f ancestor="$DOCKER_IMG")
+
+set +x
+
+# Tail the logs of the container so we can see the build output
+docker logs -f "$CID"
+
+# Wait for the container to exit when the CI command is done.
+errno=$(docker wait "$CID")
+
+docker-compose down
+
+exit $errno


### PR DESCRIPTION
Script `run-composed` to use `docker-compose` when running more complicated CI jobs. 

This allows you to use a custom `docker-compose.yml` file so you can depend on some more services to run those outside of your normal docker CI worker.